### PR TITLE
feat: issue/24 - adds blocks and blocked by counts for each issue

### DIFF
--- a/bin/kraken
+++ b/bin/kraken
@@ -1,4 +1,3 @@
 #!/usr/bin/env node
-
-require = require('esm')(module /*, options*/);
-require('../dist').cli(process.argv);
+import { cli } from '../dist/index.js';
+cli(process.argv);

--- a/bin/postinstall
+++ b/bin/postinstall
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-const fs = require('node:fs');
-const { resolve } = require('node:path');
-const { homedir } = require('node:os');
-const { execSync } = require('node:child_process');
+import fs from 'node:fs';
+import { resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { execSync } from 'node:child_process';
 
 const dirPath = resolve(homedir(), '.kraken');
 const configTemplatePath = resolve('config-template.json');
@@ -18,7 +18,7 @@ const getConfigTemplate = async () => new Promise((resolve, reject) => {
 
       const buffer = new Buffer.alloc(stats.size);
 
-      fs.read(fd, buffer, 0, buffer.length, null, function (readError, bytesRead, buffer) {
+      fs.read(fd, buffer, 0, buffer.length, null, function (readError, bytesRead, buffer, position, bytesRequested) {
         if (readError) return reject(readError);
         let data;
 
@@ -46,7 +46,7 @@ const getPRTemplate = async () => new Promise((resolve, reject) => {
 
       const buffer = new Buffer.alloc(stats.size);
 
-      fs.read(fd, buffer, 0, buffer.length, null, function (readError, bytesRead, buffer) {
+      fs.read(fd, buffer, 0, buffer.length, null, function (readError, bytesRead, buffer, position, bytesRequested) {
         if (readError) return reject(readError);
         let data;
 
@@ -71,6 +71,7 @@ const createConfig = async () => new Promise((resolve, reject) => {
         // TODO: add support for updating the config file with any new/missing fields
 
         console.warn('[!] config file already exists. skipping creating it');
+        return;
       }
   
       throw err;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "arg": "^5.0.2",
-        "dayjs": "^1.11.13",
-        "esm": "^3.2.25"
+        "dayjs": "^1.11.13"
       },
       "bin": {
         "kraken": "bin/kraken"
@@ -798,14 +797,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "",
   "main": "src/index.ts",
+  "type": "module",
   "bin": {
     "kraken": "bin/kraken"
   },
@@ -29,7 +30,6 @@
   },
   "dependencies": {
     "arg": "^5.0.2",
-    "dayjs": "^1.11.13",
-    "esm": "^3.2.25"
+    "dayjs": "^1.11.13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kraken",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "src/index.ts",
   "type": "module",

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -1,7 +1,7 @@
-import { FatalError } from '../lib/error';
-import { Logger } from '../lib/logger';
-import { Parser } from '../lib/parser';
-import { IContext } from '../types';
+import { FatalError } from '../lib/error.js';
+import { Logger } from '../lib/logger.js';
+import { Parser } from '../lib/parser.js';
+import { IContext } from '../types.js';
 
 export interface ICommandProps {
   pattern: string;

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { IContext } from '../types';
-import { Command } from './command';
-import { Logger } from '../lib/logger';
-import { FatalError } from '../lib/error';
+import { IContext } from '../types.js';
+import { Command } from './command.js';
+import { Logger } from '../lib/logger.js';
+import { FatalError } from '../lib/error.js';
 import dayjs from 'dayjs';
 
 class FilesCommand extends Command {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import { IContext } from '../types';
-import { Command } from './command';
-import { commands } from '.';
-import { FatalError } from '../lib/error';
-import { Logger } from '../lib/logger';
+import { IContext } from '../types.js';
+import { Command } from './command.js';
+import { commands } from './index.js';
+import { FatalError } from '../lib/error.js';
+import { Logger } from '../lib/logger.js';
 
 class HelpCommand extends Command {
   constructor() {
@@ -37,7 +37,7 @@ class HelpCommand extends Command {
     let version = '';
   
     try {
-      const packageJson = JSON.parse(fs.readFileSync(path.join(require.main!.filename, '..', '..', 'package.json'), 'utf8'));
+      const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), '..', '..', 'package.json'), 'utf8'));
       version = `v${packageJson.version}`;
     } catch (err: any) {
       Logger.error(`\nhelp:printGenDocs error\n\nunable to retrieve kraken version\n${err.message}\n`);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,3 +1,12 @@
+import type { IContext } from '../types.js';
+import * as filesCmd from './files.js';
+import * as helpCmd from './help.js';
+import * as issuesCmd from './issues.js';
+import * as prepareCmd from './prepare.js';
+import * as projectsCmd from './projects.js';
+import * as releaseCmd from './release.js';
+import * as statusesCmd from './statuses.js';
+
 export const commands = new Set([
     'files',
     'help',
@@ -6,4 +15,20 @@ export const commands = new Set([
     'projects',
     'release',
     'statuses',
-  ]);
+]);
+
+export interface CommandModule {
+    exec: (ctx: IContext) => Promise<IContext>;
+    help: () => void;
+}
+
+// Create a static mapping of commands
+export const commandRegistry: Record<string, CommandModule> = {
+    files: { exec: filesCmd.exec, help: filesCmd.help },
+    help: { exec: helpCmd.exec, help: helpCmd.help },
+    issues: { exec: issuesCmd.exec, help: issuesCmd.help },
+    prepare: { exec: prepareCmd.exec, help: prepareCmd.help },
+    projects: { exec: projectsCmd.exec, help: projectsCmd.help },
+    release: { exec: releaseCmd.exec, help: releaseCmd.help },
+    statuses: { exec: statusesCmd.exec, help: statusesCmd.help },
+};

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -3,11 +3,11 @@ import os from 'os';
 import path from 'path';
 import readline from 'readline';
 import { execSync } from 'child_process';
-import { IContext, IIssue, IQuery, IReport } from '../types';
-import { Command } from './command';
-import { Logger } from '../lib/logger';
-import { FatalError } from '../lib/error';
 import dayjs from 'dayjs';
+import { IContext, IIssue, IQuery, IReport } from '../types.js';
+import { Command } from './command.js';
+import { Logger } from '../lib/logger.js';
+import { FatalError } from '../lib/error.js';
 
 class PrepareCommand extends Command {
     private platforms = new Set(['github']);

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -1,7 +1,7 @@
-import { IContext, IProject } from '../types';
-import { Command } from './command';
-import { Logger } from '../lib/logger';
-import { FatalError } from '../lib/error';
+import { IContext, IProject } from '../types.js';
+import { Command } from './command.js';
+import { Logger } from '../lib/logger.js';
+import { FatalError } from '../lib/error.js';
 
 class ProjectsCommand extends Command {
     private platforms = new Set(['jira']);
@@ -104,7 +104,8 @@ class ProjectsCommand extends Command {
                 throw new FatalError(`Failed to get projects from Jira: ${res.statusText}`);
             }
         
-            const data = await res.json();
+            // TODO: come back and update type form any to actual type as defined by the Jira API
+            const data = await res.json() as { values: any[] };
     
             return data.values.map((project: any) => {
                 return {

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -2,10 +2,10 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { execSync } from 'child_process';
-import { IContext, IPreparedData } from '../types';
-import { Command } from './command';
-import { Logger } from '../lib/logger';
-import { FatalError } from '../lib/error';
+import { IContext, IPreparedData } from '../types.js';
+import { Command } from './command.js';
+import { Logger } from '../lib/logger.js';
+import { FatalError } from '../lib/error.js';
 import dayjs from 'dayjs';
 
 class ReleaseCommand extends Command {
@@ -169,7 +169,7 @@ class ReleaseCommand extends Command {
                 throw new FatalError(`Failed to create pull request: ${error}`);
             }
     
-            const pr = await res.json();
+            const pr = await res.json() as { html_url: string };
             Logger.success(`Successfully created pull request: ${pr.html_url}`);
         } catch (err) {
             if (err instanceof FatalError) {

--- a/src/commands/statuses.ts
+++ b/src/commands/statuses.ts
@@ -1,7 +1,7 @@
-import { IContext, IStatus } from '../types';
-import { Command } from './command';
-import { Logger } from '../lib/logger';
-import { FatalError } from '../lib/error';
+import { IContext, IStatus } from '../types.js';
+import { Command } from './command.js';
+import { Logger } from '../lib/logger.js';
+import { FatalError } from '../lib/error.js';
 
 class StatusesCommand extends Command {
     private platforms = new Set(['jira']);
@@ -115,7 +115,8 @@ class StatusesCommand extends Command {
                 throw new FatalError(`Failed to get statuses from Jira: ${res.statusText}`);
             }
 
-            const data = await res.json();
+            // TODO: come back and update type form any to actual type as defined by the Jira API
+            const data = await res.json() as any[];
 
             const story = data.find((item: any) => item.name === 'Story');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
-import { commands } from './commands';
-import { FatalError } from './lib/error';
-import { Logger } from './lib/logger';
-import { Parser } from './lib/parser';
-import { IContext } from './types';
-import { getConfig } from './utils/config';
+import { commands, commandRegistry } from './commands/index.js';
+import { FatalError } from './lib/error.js';
+import { Logger } from './lib/logger.js';
+import { Parser } from './lib/parser.js';
+import { IContext } from './types.js';
+import { getConfig } from './utils/config.js';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 export function cli(args: [string, string, string, ...string[]]) {
   const parsed = { ...Parser.init(...args) };
@@ -23,23 +25,35 @@ export function cli(args: [string, string, string, ...string[]]) {
     process.exit(1);
   }
   
-  if ((ctx.command !== '--version' && ctx.command !== '-v' && !commands.has(ctx.command))
-  ) {
+  // Handle version command directly
+  if (ctx.command === '--version' || ctx.command === '-v') {
+    try {
+      const packageJson = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf8'));
+      Logger.log(packageJson.version);
+      process.exit(0);
+    } catch (err) {
+      Logger.error('Failed to read version information');
+      process.exit(1);
+    }
+  }
+
+  const command = ctx.command;
+  
+  if (!commands.has(command)) {
     Logger.error('invalid command');
     process.exit(1);
   }
 
-  const command = (ctx.command === '--version' || ctx.command === '-v')
-    ? 'printversion'
-    : ctx.command;
+  const commandModule = commandRegistry[command];
+  if (!commandModule) {
+    Logger.error(`Command module ${command} not found`);
+    process.exit(1);
+  }
 
   getConfig()
     .then(config => {
       ctx.config = config;
-      return import(`./commands/${command}`);
-    })
-    .then((module: any) => {
-      return module.exec(ctx);
+      return commandModule.exec(ctx);
     })
     .then((ctx: IContext) => {
       if ('preventCompletion' in ctx && ctx.preventCompletion) {
@@ -50,7 +64,6 @@ export function cli(args: [string, string, string, ...string[]]) {
     })
     .catch((err: Error) => {
       Logger.error(err);
-
       if (err instanceof FatalError) process.exit(1);
     });
 }

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -1,6 +1,6 @@
 import os from 'os';
-import { FatalError } from './error';
-import { IContext } from '../types';
+import { FatalError } from './error.js';
+import { IContext } from '../types.js';
 
 interface IPattern {
   name: string;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { IConfig } from '../types';
+import { IConfig } from '../types.js';
 
 const ConfigPath = path.resolve(os.homedir(), '.kraken', 'config.json');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "lib": ["ES2020"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -13,7 +13,10 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "ES2020",
-    "useDefineForClassFields": true
+    "useDefineForClassFields": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
   },
-  "include": ["."]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Resolves #24 

Adds new Blocks and Blocked By columns to the report generated by the `issues` command. Now, if any issue to be released is either Blocking another ticket, or Is Blocked By another ticket, the count of each of these is displayed so we can easily tell if a ticket relies on another tickets.

*This update also includes refactors so kraken can run on later versions of Node.*