### PR TITLE
issue/25 - resolves prepare command only returning 1 manually entered query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kraken",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "",
   "main": "src/index.ts",
   "type": "module",

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -376,9 +376,9 @@ class PrepareCommand extends Command {
         Logger.log('\n----------------oldest----------------');
     }
 
-    private promptForQuery = (ctx: IContext) => new Promise<IQuery[]>((resolve, reject) => {
+    private promptForQuery = (ctx: IContext, existingInputs: IQuery[] = []) => new Promise<IQuery[]>((resolve, reject) => {
         try {
-            const inputs: IQuery[] = [];
+            const inputs = [...existingInputs];
 
             const rd = readline.createInterface({
                 input: process.stdin,
@@ -414,7 +414,7 @@ class PrepareCommand extends Command {
                     if (normalized === 'n') {
                         resolve(inputs);
                     } else {
-                        this.promptForQuery(ctx).then(resolve);
+                        this.promptForQuery(ctx, inputs).then(resolve);
                     }
                 });
             });


### PR DESCRIPTION
Resolves #25 

Fixes issue with the `prepare` command only returning the results of the last query when queries were entered manually.